### PR TITLE
Adds one-dimensional source mixture plot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ReSources
 Title: Food Reconstruction Using Isotopic Transferred Signals
-Version: 24.08.1
+Version: 24.08.2
 Authors@R: c(
     person("Marcus", "Gross", email = "marcus.gross@inwt-statistics.de", role = c("aut", "cre")),
     person("Ricardo", "Fernandes", email = "ldv1452@gmail.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # ReSources 24.08.2
 
-## Updates
+## New Features
 - Adds one-dimensional source mixture plot in addition to available 2- and 3dimensional ones
 
 # ReSources 24.08.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# ReSources 24.08.2
+
+## Updates
+- Adds one-dimensional source mixture plot in addition to available 2- and 3dimensional ones
+
 # ReSources 24.08.1
 
 ## Bug Fixes

--- a/R/01-ui.R
+++ b/R/01-ui.R
@@ -800,7 +800,7 @@ fruitsUI <- function(id, title = "FRUITS") {
                   value = "sourceMixPlot",
                   pickerInput(
                     inputId = ns("sourceSelectMix"),
-                    label = "Select two or three proxies",
+                    label = "Select one, two or three proxies",
                     choices = NULL,
                     selected = NULL,
                     multiple = TRUE

--- a/R/01-ui.R
+++ b/R/01-ui.R
@@ -688,10 +688,12 @@ fruitsUI <- function(id, title = "FRUITS") {
                 choices = c("horizontal", "vertical"),
                 selected = "vertical"
               ),
-              tags$p("Click on simulate for additional characteristics"),
+              tags$hr(),
+              helpText("Click on 'Simulate' for additional characteristics:"),
               div(foodIntakesButton(
                 ns("foodIntakes"), "Add Source Contributions"
               )),
+              tags$br(),
               div(
                 sliderInput(
                   ns("seqSim"),
@@ -709,6 +711,7 @@ fruitsUI <- function(id, title = "FRUITS") {
                 multiple = TRUE
               ),
               div(actionButton(ns("runModelChar"), "Simulate")),
+              tags$br(),
               conditionalPanel(
                 condition = "output.statusSim == 'COMPLETED'",
                 ns = ns,

--- a/R/04-prognosis.R
+++ b/R/04-prognosis.R
@@ -316,18 +316,12 @@ sourceTargetPlot <- function(simSources = NULL,
       return(plot)
     }
     if ((length(sources) < 3 & length(targets) > 1) | (length(sources) < 2 & length(targets) == 1)) {
-      if(length(targets) > 1){
-        data <- data.frame(
-          Message = c("Please select at least 3 sources"),
-          Proxy1 <- c(0), Proxy2 <- c(1)
-        )
-      }
-      if(length(targets) ==1){
-        data <- data.frame(
-          Message = c("Please select at least 2 sources"),
-          Proxy1 <- c(0), Proxy2 <- c(1)
-        )
-      }
+      minNSources <- ifelse(length(targets) > 1, 3, 2)
+      data <- data.frame(
+        Message = sprintf("Please select at least %s sources", minNSources),
+        Proxy1 = c(0), 
+        Proxy2 = c(1)
+      )
       
       plot <- plot_ly(data,
         x = ~Proxy1, y = ~Proxy2,

--- a/R/04-prognosis.R
+++ b/R/04-prognosis.R
@@ -298,11 +298,10 @@ sourceTargetPlot <- function(simSources = NULL,
     targetErrors <- fruitsObj$data$obsvnError
     covariateValues <- fruitsObj$data$covariates
   }
-
   if (!is.null(sources)) {
-    if (!(length(targets) %in% c(2, 3))) {
+    if (!(length(targets) %in% c(1, 2, 3))) {
       data <- data.frame(
-        Message = c("Please select 2 or 3 proxies"),
+        Message = c("Please select 1, 2 or 3 proxies"),
         Proxy1 <- c(0), Proxy2 <- c(1)
       )
       plot <- plot_ly(data,
@@ -316,11 +315,20 @@ sourceTargetPlot <- function(simSources = NULL,
       }
       return(plot)
     }
-    if (length(sources) < 3) {
-      data <- data.frame(
-        Message = c("Please select at least 3 sources"),
-        Proxy1 <- c(0), Proxy2 <- c(1)
-      )
+    if ((length(sources) < 3 & length(targets) > 1) | (length(sources) < 2 & length(targets) == 1)) {
+      if(length(targets) > 1){
+        data <- data.frame(
+          Message = c("Please select at least 3 sources"),
+          Proxy1 <- c(0), Proxy2 <- c(1)
+        )
+      }
+      if(length(targets) ==1){
+        data <- data.frame(
+          Message = c("Please select at least 2 sources"),
+          Proxy1 <- c(0), Proxy2 <- c(1)
+        )
+      }
+      
       plot <- plot_ly(data,
         x = ~Proxy1, y = ~Proxy2,
         mode = "text", type = "scatter",
@@ -424,7 +432,12 @@ sourceTargetPlot <- function(simSources = NULL,
       }
     }
   }
+  if (!is.null(sources)) {
+    means <- means[rownames(means) %in% sources, ,drop=FALSE]
+    covs <- covs[names(covs) %in% sources]
+  }
   names <- rownames(means)
+  
   colorsPlot <- colorRampPalette(brewer.pal(max(3, min(8, nrow(means))), "Set2"))(length(unique(rownames(means))))[rownames(means) %>%
     factor() %>%
     as.numeric()]
@@ -437,6 +450,16 @@ sourceTargetPlot <- function(simSources = NULL,
         error = round(qnorm(1 - (1 - confidence) / 2) * sqrt(unlist(covs)), 3),
         colorsPlot = colorsPlot
       )
+      if((showGrid | showPoints) & (!is.null(sources))){
+        simData <- data.frame(
+          y = round(meansAll[, 1], 3),
+          x = sapply(1:nrow(simGrid),
+                     function(i) paste(paste0(colnames(simGrid), ":", round(simGrid[i, ],3)), collapse = ", ")),
+          error = round(qnorm(1 - (1 - confidence) / 2) * sqrt(unlist(covsAll)), 3),
+          colorsPlot = "blue"
+        )
+        plotData <- rbind(simData, plotData)
+      }
     }
     if (showIndividuals == TRUE) {
       if (!is.null(simSources)) {
@@ -453,7 +476,7 @@ sourceTargetPlot <- function(simSources = NULL,
           targetErrors[, targets], 3),
         colorsPlot = cols
       )
-      plotData <- rbind(plotData, individualData)
+      plotData <- rbind(individualData, plotData)
     }
     if (!is.null(userDefinedSim)) {
       cols <- colorRampPalette(brewer.pal(max(3, min(8, nrow(means))), "Set3"))(nrow(meansUser))
@@ -463,7 +486,7 @@ sourceTargetPlot <- function(simSources = NULL,
         error = round(qnorm(1 - (1 - confidence) / 2) * sqrt(unlist(covsUser)), 3),
         colorsPlot = cols
       )
-      plotData <- rbind(plotData, userData)
+      plotData <- rbind(userData, plotData)
     }
 
 
@@ -480,7 +503,7 @@ sourceTargetPlot <- function(simSources = NULL,
           )
         }
       ))
-      plotData <- rbind(plotData, covData)
+      plotData <- rbind(covData, plotData)
     }
     if (!is.null(concentrationValues)) {
       concData <- data.frame(
@@ -490,7 +513,7 @@ sourceTargetPlot <- function(simSources = NULL,
           concentrationErrors[, fractions], 3),
         colorsPlot = colorsPlot
       )
-      plotData <- rbind(plotData, concData)
+      plotData <- rbind(concData, plotData)
     }
     plotData$x <- factor(plotData$x, levels = unique(plotData$x))
     plotData <- plotData %>% arrange_(~x)


### PR DESCRIPTION
This adds the feature:  "In ReSources simulate source end points for 1-proxy" as part of the remaining tasks. This plot is consistent to the other plots (both 2d/3d source mixture  as well as 1d target values plot and other):

vertical
![grafik](https://github.com/user-attachments/assets/9644313d-d559-489b-b7c1-01e92090b1a2)
horizontal:
![grafik](https://github.com/user-attachments/assets/4031eed7-8bb1-48a1-9a4c-dc156a4f212f)

@arunge: can you have a look at it? it is not that large