### PR TITLE
ReSources 25.06.0: fix nimble options

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ReSources
 Title: Food Reconstruction Using Isotopic Transferred Signals
-Version: 25.03.2
+Version: 25.06.0
 Authors@R: c(
     person("Marcus", "Gross", email = "marcus.gross@inwt-statistics.de", role = c("aut", "cre")),
     person("Ricardo", "Fernandes", email = "ldv1452@gmail.com", role = c("aut")),
@@ -26,6 +26,7 @@ Imports:
   grDevices,
   htmltools,
   modules,
+  nimble (>= 0.13.0),
   openxlsx,
   plotly,
   RColorBrewer,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# ReSources 25.06.0
+
+## Bug Fixes
+- fixed an issue with nimble versions newer than 0.13.0, where different settings need to be applied
+  to receive the previous behavior (#142)
+
 # ReSources 25.03.2
 
 ## Updates

--- a/R/04-runModel.R
+++ b/R/04-runModel.R
@@ -16,7 +16,9 @@ compileRunModel <- function(fruitsObj, progress = FALSE, onlySim = FALSE,
   nimbleOptions(
     showCompilerOutput = FALSE,
     verboseErrors = FALSE,
-    checkNimbleFunction = FALSE
+    checkNimbleFunction = FALSE,
+    MCMCusePredictiveDependenciesInCalculations = TRUE,
+    MCMCorderPosteriorPredictiveSamplersLast = FALSE
   )
   # nimble bug mitigation
   if (fruitsObj$constants$nFractions == 1) {


### PR DESCRIPTION
# ReSources 25.06.0

## Bug Fixes
- fixed an issue with nimble versions newer than 0.13.0, where different settings need to be applied
  to receive the previous behavior (#142)