### PR TITLE
ReSources 25.06.3: fix nimble

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
   grDevices,
   htmltools,
   modules,
-  nimble (== 1.0.1),
+  nimble (== 1.3.0),
   openxlsx,
   plotly,
   RColorBrewer,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ReSources
 Title: Food Reconstruction Using Isotopic Transferred Signals
-Version: 25.06.2
+Version: 25.06.3
 Authors@R: c(
     person("Marcus", "Gross", email = "marcus.gross@inwt-statistics.de", role = c("aut", "cre")),
     person("Ricardo", "Fernandes", email = "ldv1452@gmail.com", role = c("aut")),
@@ -26,7 +26,7 @@ Imports:
   grDevices,
   htmltools,
   modules,
-  nimble (>= 0.13.0),
+  nimble (== 1.0.1),
   openxlsx,
   plotly,
   RColorBrewer,

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN Rscript -e "reticulate::install_miniconda(); \
                 reticulate::use_miniconda('r-reticulate'); \
                 reticulate::conda_install('r-reticulate', c('python-kaleido', 'packaging')); \
                 reticulate::conda_install('r-reticulate', 'plotly', channel = 'plotly'); \
-                reticulate::use_miniconda('r-reticulate')" \
+                reticulate::use_miniconda('r-reticulate') \
+                install.packages('https://cran.r-project.org/src/contrib/Archive/nimble/nimble_1.0.1.tar.gz', repos = NULL)" \
     && installPackage DSSM \
     && installPackage
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/pandora-isomemo/base-image:latest
 
 RUN adduser --system --disabled-password --home /home/inwt inwt
-ENV HOME /home/inwt 
+ENV HOME=/home/inwt 
 USER inwt
 
 ADD . .
@@ -11,7 +11,7 @@ RUN Rscript -e "reticulate::install_miniconda(); \
                 reticulate::conda_install('r-reticulate', c('python-kaleido', 'packaging')); \
                 reticulate::conda_install('r-reticulate', 'plotly', channel = 'plotly'); \
                 reticulate::use_miniconda('r-reticulate'); \
-                install.packages('https://cran.r-project.org/src/contrib/Archive/nimble/nimble_1.0.1.tar.gz', repos = NULL)" \
+                install.packages('nimble', repos = 'https://packagemanager.posit.co/cran/__linux__/noble/2025-03-01', version = '1.3.0')" \
     && installPackage DSSM \
     && installPackage
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN Rscript -e "reticulate::install_miniconda(); \
                 reticulate::use_miniconda('r-reticulate'); \
                 reticulate::conda_install('r-reticulate', c('python-kaleido', 'packaging')); \
                 reticulate::conda_install('r-reticulate', 'plotly', channel = 'plotly'); \
-                reticulate::use_miniconda('r-reticulate') \
+                reticulate::use_miniconda('r-reticulate'); \
                 install.packages('https://cran.r-project.org/src/contrib/Archive/nimble/nimble_1.0.1.tar.gz', repos = NULL)" \
     && installPackage DSSM \
     && installPackage

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN Rscript -e "reticulate::install_miniconda(); \
                 reticulate::conda_install('r-reticulate', c('python-kaleido', 'packaging')); \
                 reticulate::conda_install('r-reticulate', 'plotly', channel = 'plotly'); \
                 reticulate::use_miniconda('r-reticulate'); \
-                install.packages('nimble', repos = 'https://packagemanager.posit.co/cran/__linux__/noble/2025-03-01', version = '1.3.0')" \
+                install.packages('nimble', repos = 'https://packagemanager.posit.co/cran/__linux__/jammy/2025-03-01', version = '1.3.0')" \
     && installPackage DSSM \
     && installPackage
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # ReSources 25.06.3
 
 ## Updates
-- fixed the nimble version to the current (nimble 1.0.1) that is used in the docker container (#150)
+- fixed the nimble version to the current (nimble 1.3.0) that is used in the docker container (#150)
 
 # ReSources 25.06.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# ReSources 25.06.3
+
+## Updates
+- fixed the nimble version to the current (nimble 1.0.1) that is used in the docker container (#150)
+
 # ReSources 25.06.2
 
 ## Bug Fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # ReSources 25.06.3
 
 ## Updates
-- fixed the nimble version to the current (nimble 1.3.0) that is used in the docker container (#150)
+- fixed the nimble version to nimble 1.3.0 (#142, #150)
 
 # ReSources 25.06.2
 


### PR DESCRIPTION
# ReSources 25.06.3

## Updates
- fixed the nimble version to nimble 1.3.0 (#142, #150)