### PR TITLE
ReSources 26.04.1: fix hiding default median

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ReSources
 Title: Food Reconstruction Using Isotopic Transferred Signals
-Version: 26.04.0
+Version: 26.04.1
 Authors@R: c(
     person("Marcus", "Gross", email = "marcus.gross@inwt-statistics.de", role = c("aut", "cre")),
     person("Ricardo", "Fernandes", email = "ldv1452@gmail.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# ReSources 26.04.1
+
+## Bug Fixes
+- Fixed an issue where the median line in boxplots could not be toggled (#154)
+
 # ReSources 26.04.0
 
 ## Updates

--- a/R/01-ui.R
+++ b/R/01-ui.R
@@ -913,12 +913,14 @@ fruitsUI <- function(id, title = "FRUITS") {
                       inputId = ns("SummaryQuantile"), # statistics[5]
                       label = "Select quantile",
                       value = 95,
+                      step = 1,
                       width = "100%"
                     ),
                     percentileSliderInput(
                       inputId = ns("SummaryQuantile2"), # statistics[6]
                       label = "Select quantile",
                       value = 99,
+                      step = 1,
                       width = "100%"
                     )
                   ),
@@ -941,6 +943,7 @@ fruitsUI <- function(id, title = "FRUITS") {
                       inputId = ns("SummaryHDI"), # statistics[10]
                       label = "credible interval",
                       value = 95,
+                      step = 1,
                       width = "100%"
                     )
                   ),

--- a/R/03-plotTargets.R
+++ b/R/03-plotTargets.R
@@ -134,12 +134,12 @@ plotTargets <- function(fruitsObj, modelResults, individual, estType = "Source c
         # hdi for boxplot:
         lower = .data$box_lower,
         upper = .data$box_upper,
-        middle = (.data$box_lower + .data$box_upper) / 2,  # geometric center
+        middle = .data$box_lower,  # hidden via fatten = 0
         ymin = .data$whisker_lower,
         ymax = .data$whisker_upper
       ),
       stat = "identity",
-      median.linetype = "blank"
+      fatten = 0
     )
 
     if (show_mean) {

--- a/R/03-plotTargets.R
+++ b/R/03-plotTargets.R
@@ -134,7 +134,7 @@ plotTargets <- function(fruitsObj, modelResults, individual, estType = "Source c
         # hdi for boxplot:
         lower = .data$box_lower,
         upper = .data$box_upper,
-        middle = .data$box_lower,  # hidden via fatten = 0
+        middle = .data$median,  # hidden via fatten = 0
         ymin = .data$whisker_lower,
         ymax = .data$whisker_upper
       ),


### PR DESCRIPTION
# ReSources 26.04.1

## Bug Fixes
- Fixed an issue where the median line in boxplots could not be toggled (#154)